### PR TITLE
html rewriting results filter

### DIFF
--- a/trunk/html-rewrite.php
+++ b/trunk/html-rewrite.php
@@ -349,7 +349,7 @@ function flying_images_rewrite_html($html) {
         $background_images = $newHtml->find('[style*=background]');
         flying_images_process_background_images($background_images, $cdn_enabled, $compression_enabled, $quality, $lazy_loading_enabled);
         
-        return $newHtml;
+        return apply_filters('flying_images_rewrite_html_processed', $newHtml);
 
     } catch (Exception $e) {
         return $html;


### PR DESCRIPTION
Hi, sometimes statically has bugs, and theme developers need a possibility to change results of Html rewriting from a theme.

For example, I have bugs with SVG and think quickly to disable quality rewriting by hook then some else.
`add_filter('flying_images_rewrite_html_processed', function($html) {
    return preg_replace("~https://cdn\.statically\.io/img/{$_SERVER['HTTP_HOST']}/(.*)\.svg\?quality=[0-9]+~", '${1}.svg', $html);
});`